### PR TITLE
Fix: clear button unselects both radio options

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,8 @@ function hideMessage() {
 
 function clearMessage() {
   message.innerText = "";
+  affirmationSelect.checked = false;
+  mantraSelect.checked = false;
   revealMessage();
 }
 


### PR DESCRIPTION
Is this a fix or a feature?
Fix

What is the change/fix?
The clearMessage function now unselects both radio buttons

Where should the reviewer start?
line 37 in main.js

How should this be tested?
make sure that pressing clear unselects both options

Screenshots(if appropriate)