### PR TITLE
Feature/local storage

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 favoriteAffirmations = [];
-favoriateMantras = [];
-favoriteAffirmations = JSON.parse(localStorage.getItem(favoriteAffirmations)) || [];
-favoriteMantras = JSON.parse(localStorage.getItem(favoriteAffirmations)) || [];
+favoriteMantras = [];
+favoriteAffirmations = JSON.parse(localStorage.getItem(`favoriteAffirmations`)) || [];
+favoriteMantras = JSON.parse(localStorage.getItem(`favoriteMantras`)) || [];
 
 //query selectors
 var mainDisplay = document.querySelector('.main');

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 favoriteAffirmations = [];
-favoriteMantras = [];
+favoriateMantras = [];
+favoriteAffirmations = JSON.parse(localStorage.getItem(favoriteAffirmations)) || [];
+favoriteMantras = JSON.parse(localStorage.getItem(favoriteAffirmations)) || [];
 
 //query selectors
 var mainDisplay = document.querySelector('.main');
@@ -129,18 +131,34 @@ function removeFromFavorites() {
   starButton.classList.toggle('filter')
   if (mantraSelect.checked) {
     favoriteMantras.splice(favoriteMantras.indexOf(message.innerText), 1)
+    removeFromLocalStorage('favoriteMantras', message.innerText)
   } else if (affirmationSelect.checked) {
     favoriteAffirmations.splice(favoriteAffirmations.indexOf(message.innerText), 1)
+    removeFromLocalStorage('favoriteAffirmations', message.innerText)
   }
 }
 
 function addToFavorites() {
   if (mantraSelect.checked && !favoriteMantras.includes(message.innerText)) {
     favoriteMantras.push(message.innerText)
+    saveToLocalStorage('favoriteMantras', message.innerText)
   } else if (affirmationSelect.checked && !favoriteAffirmations.includes(message.innerText)) {
     favoriteAffirmations.push(message.innerText)
+    saveToLocalStorage('favoriteAffirmations', message.innerText)
   }
   starButton.classList.remove('filter')
+}
+
+function saveToLocalStorage(arrayName, message) {
+  var arrayData = JSON.parse(localStorage.getItem(arrayName)) || [];
+  arrayData.push(message);
+  localStorage.setItem(arrayName, JSON.stringify(arrayData));
+}
+
+function removeFromLocalStorage(arrayName, message) {
+  var arrayData = JSON.parse(localStorage.getItem(arrayName));
+  arrayData.splice(arrayData.indexOf(message), 1);
+  localStorage.setItem(arrayName, JSON.stringify(arrayData));
 }
 
 function displayFavorites() {

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,5 @@
-favoriteAffirmations = [];
-favoriteMantras = [];
-favoriteAffirmations = JSON.parse(localStorage.getItem(`favoriteAffirmations`)) || [];
-favoriteMantras = JSON.parse(localStorage.getItem(`favoriteMantras`)) || [];
+var favoriteAffirmations = JSON.parse(localStorage.getItem(`favoriteAffirmations`)) || [];
+var favoriteMantras = JSON.parse(localStorage.getItem(`favoriteMantras`)) || [];
 
 //query selectors
 var mainDisplay = document.querySelector('.main');
@@ -95,6 +93,7 @@ function deleteMessage() {
   }
   message.innerText = `Message deleted.`;
   starButton.classList.add('hidden');
+  removeFromFavorites();
   toggleConfirm();
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,7 @@ var backButton = document.querySelector('.back-to-main');
 var deleteButton = document.querySelector('.delete-button')
 var yesButton = document.querySelector('.yes')
 var noButton = document.querySelector('.no')
+var resetButton = document.querySelector('.remove-data')
 
 //event listeners
 messageButton.addEventListener('click', displayMessage);
@@ -40,6 +41,7 @@ backButton.addEventListener('click', toggleFavorites);
 deleteButton.addEventListener('click', toggleConfirm)
 yesButton.addEventListener('click', deleteMessage)
 noButton.addEventListener('click', toggleConfirm)
+resetButton.addEventListener('click', alertReset)
 
 //event handlers
 function displayMessage() {
@@ -97,6 +99,13 @@ function deleteMessage() {
   message.innerText = `Message deleted.`;
   starButton.classList.add('hidden');
   toggleConfirm();
+}
+
+function alertReset() {
+  if (confirm('This will reset all page data. Are you sure?')) {
+    localStorage.clear();
+    window.location.reload();
+  }
 }
 
 //helper functions

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 var favoriteAffirmations = JSON.parse(localStorage.getItem(`favoriteAffirmations`)) || [];
 var favoriteMantras = JSON.parse(localStorage.getItem(`favoriteMantras`)) || [];
+affirmations = JSON.parse(localStorage.getItem('affirmations')) || affirmations;
+mantras = JSON.parse(localStorage.getItem('mantras')) || mantras;
 
 //query selectors
 var mainDisplay = document.querySelector('.main');
@@ -91,9 +93,9 @@ function deleteMessage() {
   } else if (affirmationSelect.checked) {
     affirmations.splice(affirmations.indexOf(message.innerText), 1)
   }
+  removeFromFavorites();
   message.innerText = `Message deleted.`;
   starButton.classList.add('hidden');
-  removeFromFavorites();
   toggleConfirm();
 }
 
@@ -130,22 +132,24 @@ function removeFromFavorites() {
   starButton.classList.toggle('filter')
   if (mantraSelect.checked) {
     favoriteMantras.splice(favoriteMantras.indexOf(message.innerText), 1)
-    removeFromLocalStorage('favoriteMantras', message.innerText)
+    removeFromLocalStorage('favoriteMantras', message.innerText, mantras);
+    removeFromLocalStorage('mantras', message.innerText, mantras);
   } else if (affirmationSelect.checked) {
     favoriteAffirmations.splice(favoriteAffirmations.indexOf(message.innerText), 1)
-    removeFromLocalStorage('favoriteAffirmations', message.innerText)
+    removeFromLocalStorage('favoriteAffirmations', message.innerText, affirmations);
+    removeFromLocalStorage('affirmations', message.innerText, affirmations);
   }
 }
 
 function addToFavorites() {
   if (mantraSelect.checked && !favoriteMantras.includes(message.innerText)) {
-    favoriteMantras.push(message.innerText)
-    saveToLocalStorage('favoriteMantras', message.innerText)
+    favoriteMantras.push(message.innerText);
+    saveToLocalStorage('favoriteMantras', message.innerText);
   } else if (affirmationSelect.checked && !favoriteAffirmations.includes(message.innerText)) {
-    favoriteAffirmations.push(message.innerText)
-    saveToLocalStorage('favoriteAffirmations', message.innerText)
+    favoriteAffirmations.push(message.innerText);
+    saveToLocalStorage('favoriteAffirmations', message.innerText);
   }
-  starButton.classList.remove('filter')
+  starButton.classList.remove('filter');
 }
 
 function saveToLocalStorage(arrayName, message) {
@@ -154,8 +158,8 @@ function saveToLocalStorage(arrayName, message) {
   localStorage.setItem(arrayName, JSON.stringify(arrayData));
 }
 
-function removeFromLocalStorage(arrayName, message) {
-  var arrayData = JSON.parse(localStorage.getItem(arrayName));
+function removeFromLocalStorage(arrayName, message, array) {
+  var arrayData = JSON.parse(localStorage.getItem(arrayName)) || array;
   arrayData.splice(arrayData.indexOf(message), 1);
   localStorage.setItem(arrayName, JSON.stringify(arrayData));
 }


### PR DESCRIPTION
Is this a fix or a feature?
Feature.

What is the change/fix?
Local storage now functions. Also added a reset button on the favorites menu that allows a user to reset the local storage.

Where should the reviewer start?
line 140 in main.js 
local storage saving and removal stars here.

How should this be tested?
Make sure any saved or deleted messages persist on page refresh and that local storage resets on reset button confirmation.

Screenshots(if appropriate)